### PR TITLE
Fix checksum check

### DIFF
--- a/lib/.github_deps/rynkowsg/shell-gr@e5a1b73/lib/checksum.bash
+++ b/lib/.github_deps/rynkowsg/shell-gr@e5a1b73/lib/checksum.bash
@@ -29,7 +29,7 @@ verify_with_checksum_string_in_file() {
   if ! command -v "${cmd}" >/dev/null; then
     log_info "Check verification skipped due to missing '${cmd}'."
   else
-    if echo "$(cat "${checksum_path}") ${file_path}" | "${cmd}" --check >/dev/null 2>&1; then
+    if echo "$(cat "${checksum_path}")" | "${cmd}" ${file_path} --check >/dev/null 2>&1; then
       log_info "Checksum verification successful: The file is intact."
     else
       log_info "Checksum verification failed: The file's integrity is compromised. Try do download file again."


### PR DESCRIPTION
When I tried downloading clj-kondo using mise, I got a checksum error. This seems to fix it. 
I don't know what Apple has changed the interface to sha256sum or what causes this.
Feel free to reject this PR, it is mostly to show a solution :)